### PR TITLE
chore(security): apply GitHub hardening policy files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners — all files require review from the repo owner
+* @icadariu

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  # Uncomment and adjust for your ecosystem(s):
+
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "gomod"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10
+
+  # - package-ecosystem: "docker"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   open-pull-requests-limit: 10

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 icadariu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security patches.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report via [GitHub private vulnerability reporting](../../security/advisories/new)
+or email the repository owner directly.
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested remediation (if any)
+
+## Response SLA
+
+| Severity | Initial response | Patch target |
+|----------|-----------------|--------------|
+| Critical | 24 hours        | 7 days       |
+| High     | 48 hours        | 14 days      |
+| Medium   | 5 business days | 30 days      |
+| Low      | 10 business days| 90 days      |
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Please allow us time to patch before
+publishing details publicly.


### PR DESCRIPTION
## What

Automated hardening policy files generated by `github-harden.py`.

### Files

| File | Purpose |
|------|---------|
| `SECURITY.md` | Vulnerability reporting process, SLA, and disclosure policy |
| `.github/CODEOWNERS` | Requires repo-owner review on all PRs |
| `.github/dependabot.yml` | Weekly Dependabot updates for GitHub Actions |
| `LICENSE` | MIT license (copyright 2026 @icadariu) |

## What was already applied directly

- ✅ Delete branch on merge
- ✅ Auto-merge enabled
- ✅ Always suggest updating pull request branches
- ✅ Web-commit signoff (DCO) required
- ✅ Private Vulnerability Reporting (PVR) — `SECURITY.md` advisory link works
- ✅ Immutable releases — published releases cannot be deleted or edited
- ✅ Dependabot vulnerability alerts
- ✅ Dependabot automated security fixes
- ✅ Secret scanning + push protection
- ✅ CodeQL default setup (best-effort; needs GHAS on private repos)
- ✅ Actions: `GITHUB_TOKEN` defaults to read-only; Actions cannot approve PRs
- ✅ Branch ruleset: PR + signed commits + no force-push + no deletion
- ✅ Tag ruleset: `v*` tags signed, non-deletable, non-force-pushable

## Next steps

1. Review and merge this PR
2. Edit `.github/dependabot.yml` to uncomment your package ecosystems
3. Ensure CI jobs are listed in the ruleset if you add required status checks