### PR TITLE
chore(security): apply GitHub hardening policy files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owners — all files require review from the repo owner
+* @icadariu

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: dependency-review
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,40 @@
+name: gitleaks
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  schedule:
+    - cron: "37 6 * * 1"
+  workflow_dispatch:
+
+# Deny-all at the workflow level; each job declares only what it needs.
+permissions: {}
+
+# Cancel superseded runs on the same ref so PR pushes don't pile up.
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: scan history for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          fetch-depth: 0
+          # gitleaks only reads history; it never pushes back. Drop the token
+          # from `.git/config` so a compromised step can't reuse it.
+          persist-credentials: false
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE is only required for organization accounts.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 icadariu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security patches.
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Report via [GitHub private vulnerability reporting](../../security/advisories/new)
+or email the repository owner directly.
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested remediation (if any)
+
+## Response SLA
+
+| Severity | Initial response | Patch target |
+|----------|-----------------|--------------|
+| Critical | 24 hours        | 7 days       |
+| High     | 48 hours        | 14 days      |
+| Medium   | 5 business days | 30 days      |
+| Low      | 10 business days| 90 days      |
+
+## Disclosure Policy
+
+We follow coordinated disclosure. Please allow us time to patch before
+publishing details publicly.


### PR DESCRIPTION
## What

Automated hardening policy files generated by `github-harden.py`.

### Files

| File | Purpose |
|------|---------|
| `SECURITY.md` | Vulnerability reporting process, SLA, and disclosure policy |
| `.github/CODEOWNERS` | Requires repo-owner review on all PRs |
| `.github/dependabot.yml` | Weekly updates for: github-actions(/) |
| `LICENSE` | MIT license (copyright 2026 @icadariu) |
| `.github/workflows/gitleaks.yml` | Secret-history scan in CI on push/PR + weekly schedule |
| `.github/workflows/dependency-review.yml` | Blocks PRs that introduce high-severity vulnerable dependencies |

## Hardening applied directly to the repository

- ✅ Delete branch on merge, auto-merge, squash-only, DCO, Wiki + Projects off
- ✅ Private Vulnerability Reporting (PVR)
- ✅ Immutable releases
- ✅ Dependabot vulnerability alerts
- ✅ Dependabot automated security fixes
- ✅ Secret scanning + push protection + non-provider patterns + validity checks
- ✅ Actions token read-only, cannot approve PRs
- ✅ Actions: `GITHUB_TOKEN` read-only; allowlist = github-owned + verified
- ✅ Branch ruleset: PR + signed commits + linear history + no force-push + no deletion
- ✅ Tag ruleset: `v*` tags signed, non-deletable, non-force-pushable

## Next steps

1. Review and merge this PR
2. Review `.github/dependabot.yml` ecosystems (auto-detected — adjust if needed)
3. Add required status checks to the branch ruleset once CI exists (start with `gitleaks / scan history for secrets`)
4. To also enable the repo-level `sha_pinning_required` Actions toggle, re-run with `--strict`. (Workflow files themselves are SHA-pinned by default.)